### PR TITLE
Make use of SteamClient optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,18 @@ function handleLogOnResponse (logOnResponse) {
 }
 
 function SteamWebLogOn (steamClient, steamUser) {
-  this._steamClient = steamClient;
-  this._steamUser = steamUser;
+  if (steamUser === undefined) {
+    this._steamUser = steamClient;
+  } else {
+    this._steamClient = steamClient;
+    this._steamUser = steamUser;
+    
+    this._steamClient.on('logOnResponse', handleLogOnResponse.bind(this));
+  }
+}
 
-  this._steamClient.on('logOnResponse', handleLogOnResponse.bind(this));
+SteamWebLogOn.prototype.setWebLoginKey = function(webLoginKey) {
+  this._webLoginKey = webLoginKey;
 }
 
 SteamWebLogOn.prototype.webLogOn = function (callback) {


### PR DESCRIPTION
In some cases it is impossible for this library to retrieve the webLoginKey, i.e. when called after the SteamClient login. This change allows to set the key manually.
